### PR TITLE
Scaling now works correctly in the new windows (fix #33)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import {App, MarkdownView, Plugin, PluginSettingTab, Setting, TFile} from 'obsidian';
+import {App, MarkdownView, Plugin, PluginSettingTab, Setting, TFile, WorkspaceWindow} from 'obsidian';
 import { Util, HandleZoomParams } from  "./src/util";
  
 
@@ -26,7 +26,7 @@ export default class MouseWheelZoomPlugin extends Plugin {
 
     async onload() {
         await this.loadSettings();
-        this.app.workspace.on("window-open", (newWindow) => this.registerEvents(newWindow.win));
+        this.app.workspace.on("window-open", (newWindow: WorkspaceWindow) => this.registerEvents(newWindow.win));
         this.registerEvents(window);
 
         this.addSettingTab(new MouseWheelZoomSettingsTab(this.app, this));
@@ -37,12 +37,13 @@ export default class MouseWheelZoomPlugin extends Plugin {
     /**
      * When the config key is released, we enable the scroll again and reset the key held down flag.
      */
-    onConfigKeyUp(currentWindow) {
+    onConfigKeyUp(currentWindow: Window) {
         this.isKeyHeldDown = false;
         this.enableScroll(currentWindow);
     }
-    onunload(currentWindow) {
-        // Re-enable the normal scrolling behaviour when the plugin unloads
+
+    onunload(currentWindow: Window = window) {
+        // Re-enable the normal scrolling behavior when the plugin unloads
         this.enableScroll(currentWindow);
     }
 
@@ -51,8 +52,8 @@ export default class MouseWheelZoomPlugin extends Plugin {
      * @param currentWindow window in which to register events
      * @private
      */
-    private registerEvents(currentWindow) {
-        const doc = currentWindow.document;
+    private registerEvents(currentWindow: Window) {
+        const doc: Document = currentWindow.document;
         this.registerDomEvent(doc, "keydown", (evt) => {
             if (evt.code === this.settings.modifierKey.toString()) {
                 this.isKeyHeldDown = true;
@@ -73,7 +74,8 @@ export default class MouseWheelZoomPlugin extends Plugin {
                     this.onConfigKeyUp(currentWindow);
                     return;
                 }
-                const eventTarget = evt.target;
+                const eventTarget: HTMLElement = evt.target as HTMLElement;
+
                 if (eventTarget.nodeName === "IMG") {
                     // Handle the zooming of the image
                     this.handleZoom(evt, eventTarget);
@@ -96,7 +98,7 @@ export default class MouseWheelZoomPlugin extends Plugin {
         let fileText = await this.app.vault.read(activeFile)
         const originalFileText = fileText;
 
-        // Get paremeters like the regex or the replacement terms based on the fact if the image is locally stored or not.
+        // Get parameters like the regex or the replacement terms based on the fact if the image is locally stored or not.
         const zoomParams: HandleZoomParams = this.getZoomParams(imageUri, fileText, eventTarget);
 
         // Check if there is already a size parameter for this image.
@@ -176,24 +178,25 @@ export default class MouseWheelZoomPlugin extends Plugin {
 
     // Utilities to disable and enable scrolling //
 
-    preventDefault(e: any) {
-        e.preventDefault();
+
+    preventDefault(ev: WheelEvent) {
+        ev.preventDefault();
     }
 
-    wheelOpt = {passive: false}
-    wheelEvent = 'wheel'
+    wheelOpt: AddEventListenerOptions = {passive: false}
+    wheelEvent = 'wheel' as keyof WindowEventMap;
 
     /**
      * Disables the normal scroll event
      */
-    disableScroll(currentWindow) {
+    disableScroll(currentWindow: Window) {
         currentWindow.addEventListener(this.wheelEvent, this.preventDefault, this.wheelOpt);
     }
  
     /**
      * Enables the normal scroll event
      */
-    enableScroll(currentWindow) {
+    enableScroll(currentWindow: Window) {
         currentWindow.removeEventListener(this.wheelEvent, this.preventDefault, this.wheelOpt);
     }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^14.14.37",
     "babel-jest": "^29.4.3",
     "jest": "^29.4.3",
-    "obsidian": "^0.12.0",
+    "obsidian": "^1.5.7-1",
     "rollup": "^2.32.1",
     "tslib": "^2.2.0",
     "typescript": "^4.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,10 +1303,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/codemirror@0.0.108":
-  version "0.0.108"
-  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.108.tgz#e640422b666bf49251b384c390cdeb2362585bde"
-  integrity sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==
+"@types/codemirror@5.60.8":
+  version "5.60.8"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-5.60.8.tgz#b647d04b470e8e1836dd84b2879988fc55c9de68"
+  integrity sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==
   dependencies:
     "@types/tern" "*"
 
@@ -2558,10 +2558,10 @@ minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-moment@2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+moment@2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 ms@2.1.2:
   version "2.1.2"
@@ -2595,13 +2595,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-obsidian@^0.12.0:
-  version "0.12.17"
-  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-0.12.17.tgz#8efe75310d0e3988cdeccfbb176d3a8ff7b363c7"
-  integrity sha512-YvCAlRym9D8zNPXt6Ez8QubSTVGoChx6lb58zqI13Dcrz3l1lgUO+pcOGDiD5Qa67nzDZLXo3aV2rqkCCpTvGQ==
+obsidian@^1.5.7-1:
+  version "1.5.7-1"
+  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-1.5.7-1.tgz#6e367f015f6a1b6b13204135434bbe3c04d4dfc3"
+  integrity sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==
   dependencies:
-    "@types/codemirror" "0.0.108"
-    moment "2.29.1"
+    "@types/codemirror" "5.60.8"
+    moment "2.29.4"
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
Fixed #33 
I added a subscription to the new window creation event and moved the registration of all zoom events to a separate method so that images in new windows can be zoomed in as well  