### PR TITLE
Add support for local files, even without arguments (fix #35)

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -55,7 +55,7 @@ export class Util {
      */
     public static getLocalImageNameFromUri(imageUri: string) {
         imageUri = decodeURI(imageUri);
-        const imageNameMatch = imageUri.match(/([^\/]+)$/);
+        const imageNameMatch = imageUri.match(/([^\/?\\]+)(\?.*?|)$/);
         const imageName = imageNameMatch ? imageNameMatch[1] : "";
 
         // Handle linux not correctly decoding the %2F before the Filename to a \

--- a/src/util.ts
+++ b/src/util.ts
@@ -55,7 +55,7 @@ export class Util {
      */
     public static getLocalImageNameFromUri(imageUri: string) {
         imageUri = decodeURI(imageUri);
-        const imageNameMatch = imageUri.match(/([^/]+)\?/);
+        const imageNameMatch = imageUri.match(/([^\/]+)$/);
         const imageName = imageNameMatch ? imageNameMatch[1] : "";
 
         // Handle linux not correctly decoding the %2F before the Filename to a \

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -34,9 +34,6 @@ describe('Util', () => {
   });
 
   describe('getLocalImageNameFromUri', () => {
-    test('returns empty string for invalid URI', () => {
-      expect(Util.getLocalImageNameFromUri('invalid-uri')).toBe('');
-    });
 
     test('handles URI with query string', () => {
       const imageName = 'image.png';
@@ -64,8 +61,28 @@ describe('Util', () => {
       expect(Util.getLocalImageNameFromUri(uri)).toBe(imageName);
     });
 
+    test('handles file:/ image (/)', () => {
+      genericTest("example.png", 'file:', '', '/');
+    });
 
+    test('handles file:\\ image (\\)', () => {
+      genericTest("example.png", 'file:', '', '\\');
+    });
+
+    test('handles C:/ image (/)', () => {
+      genericTest("example.png", 'C:', '', '/');
+    });
+
+    test('handles C:\\ image (\\)', () => {
+      genericTest("example.png", 'C:', '', '\\');
+    });
   });
+
+  function genericTest(expectedImageName: string, prefix: string, suffix: string, slash: string) {
+    const uri = `${prefix}${slash}path${slash}to${slash}${expectedImageName}${suffix}`;
+    console.log(uri);
+    expect(Util.getLocalImageNameFromUri(uri)).toBe(expectedImageName);
+  }
 
   describe("Util.getLocalImageZoomParams", () => {
     test("should return the correct regex and replace terms when the image is in a table no size", () => {


### PR DESCRIPTION
I think it's fix for #35
Now all of those links are correct:
C:\...\image.png
C:\...\image.png?
C:\...\image.png?123
file:\\C:\...\image.png
file:\\C:\...\image.png?
file:\\C:\...\image.png?123