### PR TITLE
feat: :sparkles: Allow horizontal scrolling when Shift is the trigger key.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -60,7 +60,11 @@ export default class MouseWheelZoomPlugin extends Plugin {
         this.registerDomEvent(doc, "keydown", (evt) => {
             if (evt.code === this.settings.modifierKey.toString()) {
                 this.isKeyHeldDown = true;
-                this.disableScroll(currentWindow);
+
+                if (this.settings.modifierKey !== ModifierKey.SHIFT && this.settings.modifierKey !== ModifierKey.SHIFT_RIGHT) { // Ignore shift to allow horizontal scrolling
+                    // Disable the normal scrolling behavior when the key is held down
+                    this.disableScroll(currentWindow);
+                }
             }
         });
         this.registerDomEvent(doc, "keyup", (evt) => {


### PR DESCRIPTION
Works both for left shift and right shift.

Part of #38