### PR TITLE
fix: :bug: Show correct value for initial size in settings

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -277,7 +277,7 @@ class MouseWheelZoomSettingsTab extends PluginSettingTab {
                     .setValue(500)
                     .setLimits(0, 1000, 25)
                     .setDynamicTooltip()
-                    .setValue(this.plugin.settings.stepSize)
+                    .setValue(this.plugin.settings.initialSize)
                     .onChange(async (value) => {
                         this.plugin.settings.initialSize = value
                         await this.plugin.saveSettings()


### PR DESCRIPTION
The settings showed the value of the step size in the initial size slider instead of the configured initial size.

Fixes #34 