### PR TITLE
Fixed new event registration according to obsidian documentation

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -30,7 +30,7 @@ export default class MouseWheelZoomPlugin extends Plugin {
     async onload() {
         await this.loadSettings();
         this.registerEvent(
-            this.app.workspace.on("window-open", (newWindow: WorkspaceWindow) => this.registerEvents(newWindow.win));
+            this.app.workspace.on("window-open", (newWindow: WorkspaceWindow) => this.registerEvents(newWindow.win))
         );
         this.registerEvents(window);
 

--- a/main.ts
+++ b/main.ts
@@ -29,7 +29,9 @@ export default class MouseWheelZoomPlugin extends Plugin {
 
     async onload() {
         await this.loadSettings();
-        this.app.workspace.on("window-open", (newWindow: WorkspaceWindow) => this.registerEvents(newWindow.win));
+        this.registerEvent(
+            this.app.workspace.on("window-open", (newWindow: WorkspaceWindow) => this.registerEvents(newWindow.win));
+        );
         this.registerEvents(window);
 
         this.addSettingTab(new MouseWheelZoomSettingsTab(this.app, this));


### PR DESCRIPTION
Obsidian docs says: 
> Any registered event handlers need to be detached whenever the plugin unloads. The safest way to make sure this happens is to use the `registerEvent()` method.

But it's not used. I changed it.

https://docs.obsidian.md/Plugins/Events