### PR TITLE
Implement zooming functionality for all canvas nodes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -85,16 +85,24 @@ export default class MouseWheelZoomPlugin extends Plugin {
                 }
 
                 const eventTarget = evt.target as Element;
-                if (eventTarget.hasClass("canvas-node-content-blocker")){
+                
+                const targetIsCanvas: boolean = eventTarget.hasClass("canvas-node-content-blocker")
+                const targetIsCanvasNode: boolean = eventTarget.closest(".canvas-node-content") !== null;
+                const targetIsImage: boolean = eventTarget.nodeName === "IMG";
+
+                if (targetIsCanvas || targetIsCanvasNode || targetIsImage) {
+                    this.disableScroll(currentWindow);
+                }
+
+                if (targetIsCanvas){                  
                     // seems we're trying to zoom on some canvas node.                    
                     this.handleZoomForCanvas(evt, eventTarget);
-                    
                 } 
-                else if (eventTarget.closest(".canvas-node-content")) {
+                else if (targetIsCanvasNode) {
                     // we trying to resize focused canvas node.
                     // i think here can be implementation of zoom images in embded markdown files on canvas. 
                 }
-                else if (eventTarget.nodeName === "IMG") {
+                else if (targetIsImage) {
                     // Handle the zooming of the image
                     this.handleZoom(evt, eventTarget);
                 }

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import {App, MarkdownView, Plugin, PluginSettingTab, Setting, TFile, WorkspaceWindow} from 'obsidian';
+import {App, MarkdownView, Plugin, PluginSettingTab, Setting, TFile, WorkspaceWindow, View} from 'obsidian';
 import { Util, HandleZoomParams } from  "./src/util";
  
 
@@ -84,7 +84,7 @@ export default class MouseWheelZoomPlugin extends Plugin {
                     return;
                 }
 
-                const eventTarget = evt.target;
+                const eventTarget = evt.target as Element;
                 if (eventTarget.hasClass("canvas-node-content-blocker")){
                     // seems we're trying to zoom on some canvas node.                    
                     this.handleZoomForCanvas(evt, eventTarget);
@@ -110,16 +110,17 @@ export default class MouseWheelZoomPlugin extends Plugin {
      */
     handleZoomForCanvas(evt: WheelEvent, eventTarget: Element) {
         // get active canvas
-        const isCanvas = app.workspace.activeLeaf.view?.getViewType() === "canvas";
+        const isCanvas: boolean = this.app.workspace.getActiveViewOfType(View).getViewType() === "canvas";
         if (!isCanvas) {
             throw new Error("Can't find canvas");
         };
-        const canvas = app.workspace.activeLeaf.view.canvas;
+        // Unfortunately the current type definitions don't include any canvas functionality...
+        const canvas = (this.app.workspace.getActiveViewOfType(View) as any).canvas;
         
-        // get triggerd canvasNode
+        // get triggered canvasNode
         const canvasNode = 
             Array.from(canvas.nodes.values())
-            .find(node => node.contentBlockerEl == eventTarget);
+            .find(node => (node as any).contentBlockerEl == eventTarget) as any;
                 
         // Adjust delta based on the direction of the resize
         let delta = evt.deltaY > 0 ? this.settings.stepSize : this.settings.stepSize * -1;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "mousewheel-image-zoom",
   "name": "Mousewheel Image zoom",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "minAppVersion": "0.9.12",
   "description": "This plugin enables you to increase/decrease the size of an image by scrolling",
   "author": "Nico Jeske",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mousewheel-image-zoom",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "This plugin enables you to increase/decrease the size of an image by scrolling",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
- Enable proportional scaling of all media attachments (images, videos, audio, PDFs), text blocks, and even Markdown files on the canvas using modifier key + mouse wheel, provided that these elements are not selected or focused for editing.
- Introduce the ability to undo node scaling via ctrl+z, as if you were undoing the scaling action performed with the mouse.

Note: Due to ongoing issue #47, normal scaling is temporarily restricted to use with the Alt key.

Related to: #37